### PR TITLE
fix: multipart/form csv is now passed correctly in all multipart/form csv imports

### DIFF
--- a/TalonOne.sln
+++ b/TalonOne.sln
@@ -1,10 +1,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TalonOne", "src\TalonOne\TalonOne.csproj", "{9488BCE0-5E86-454A-9181-9AB2E7D3F3BF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TalonOne", "src\TalonOne\TalonOne.csproj", "{9488BCE0-5E86-454A-9181-9AB2E7D3F3BF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TalonOne.Test", "src\TalonOne.Test\TalonOne.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TalonOne.Test", "src\TalonOne.Test\TalonOne.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,8 +23,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {A32542E0-F714-460D-BBD2-971823D8C460}
 	EndGlobalSection
 EndGlobal

--- a/TalonOne.sln
+++ b/TalonOne.sln
@@ -1,10 +1,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TalonOne", "src\TalonOne\TalonOne.csproj", "{9488BCE0-5E86-454A-9181-9AB2E7D3F3BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TalonOne", "src\TalonOne\TalonOne.csproj", "{9488BCE0-5E86-454A-9181-9AB2E7D3F3BF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TalonOne.Test", "src\TalonOne.Test\TalonOne.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TalonOne.Test", "src\TalonOne.Test\TalonOne.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A32542E0-F714-460D-BBD2-971823D8C460}
 	EndGlobalSection
 EndGlobal

--- a/src/TalonOne/Api/ManagementApi.cs
+++ b/src/TalonOne/Api/ManagementApi.cs
@@ -10,11 +10,7 @@
 
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Net;
-using System.Net.Mime;
+using System.IO;
 using TalonOne.Client;
 using TalonOne.Model;
 using Attribute = TalonOne.Model.Attribute;
@@ -16312,9 +16308,12 @@ namespace TalonOne.Api
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
             localVarRequestOptions.PathParameters.Add("collectionId", TalonOne.Client.ClientUtils.ParameterToString(collectionId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16325,6 +16324,12 @@ namespace TalonOne.Api
 
             // make the HTTP request
             var localVarResponse = this.Client.Post< Import >("/v1/applications/{applicationId}/campaigns/{campaignId}/collections/{collectionId}/import", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16383,9 +16388,12 @@ namespace TalonOne.Api
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
             localVarRequestOptions.PathParameters.Add("collectionId", TalonOne.Client.ClientUtils.ParameterToString(collectionId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16397,6 +16405,12 @@ namespace TalonOne.Api
             // make the HTTP request
 
             var localVarResponse = await this.AsynchronousClient.PostAsync<Import>("/v1/applications/{applicationId}/campaigns/{campaignId}/collections/{collectionId}/import", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16450,9 +16464,12 @@ namespace TalonOne.Api
 
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
-            if (upFile != null)
+
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16463,6 +16480,12 @@ namespace TalonOne.Api
 
             // make the HTTP request
             var localVarResponse = this.Client.Post< Import >("/v1/applications/{applicationId}/campaigns/{campaignId}/import_coupons", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16518,9 +16541,12 @@ namespace TalonOne.Api
             
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16532,6 +16558,12 @@ namespace TalonOne.Api
             // make the HTTP request
 
             var localVarResponse = await this.AsynchronousClient.PostAsync<Import>("/v1/applications/{applicationId}/campaigns/{campaignId}/import_coupons", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16582,9 +16614,12 @@ namespace TalonOne.Api
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
             localVarRequestOptions.PathParameters.Add("programID", TalonOne.Client.ClientUtils.ParameterToString(programID)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16595,6 +16630,12 @@ namespace TalonOne.Api
 
             // make the HTTP request
             var localVarResponse = this.Client.Post< Import >("/v1/loyalty_programs/{programID}/import_points", localVarRequestOptions, this.Configuration);
+
+            if(upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16647,9 +16688,12 @@ namespace TalonOne.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
             localVarRequestOptions.PathParameters.Add("programID", TalonOne.Client.ClientUtils.ParameterToString(programID)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16661,6 +16705,12 @@ namespace TalonOne.Api
             // make the HTTP request
 
             var localVarResponse = await this.AsynchronousClient.PostAsync<Import>("/v1/loyalty_programs/{programID}/import_points", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16711,9 +16761,12 @@ namespace TalonOne.Api
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
             localVarRequestOptions.PathParameters.Add("poolId", TalonOne.Client.ClientUtils.ParameterToString(poolId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16724,6 +16777,12 @@ namespace TalonOne.Api
 
             // make the HTTP request
             var localVarResponse = this.Client.Post< Import >("/v1/giveaways/pools/{poolId}/import", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16776,9 +16835,12 @@ namespace TalonOne.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
             localVarRequestOptions.PathParameters.Add("poolId", TalonOne.Client.ClientUtils.ParameterToString(poolId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16790,6 +16852,12 @@ namespace TalonOne.Api
             // make the HTTP request
 
             var localVarResponse = await this.AsynchronousClient.PostAsync<Import>("/v1/giveaways/pools/{poolId}/import", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16843,9 +16911,12 @@ namespace TalonOne.Api
 
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16856,6 +16927,12 @@ namespace TalonOne.Api
 
             // make the HTTP request
             var localVarResponse = this.Client.Post< Import >("/v1/applications/{applicationId}/campaigns/{campaignId}/import_referrals", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {
@@ -16911,9 +16988,12 @@ namespace TalonOne.Api
             
             localVarRequestOptions.PathParameters.Add("applicationId", TalonOne.Client.ClientUtils.ParameterToString(applicationId)); // path parameter
             localVarRequestOptions.PathParameters.Add("campaignId", TalonOne.Client.ClientUtils.ParameterToString(campaignId)); // path parameter
-            if (upFile != null)
+            
+            MemoryStream upFileStream = null;
+            if (!String.IsNullOrEmpty(upFile))
             {
-                localVarRequestOptions.FormParameters.Add("upFile", TalonOne.Client.ClientUtils.ParameterToString(upFile)); // form parameter
+                upFileStream = TalonOne.Client.ClientUtils.ParameterToStream(upFile);
+                localVarRequestOptions.FileParameters.Add("upFile", upFileStream); // file parameter
             }
 
             // authentication (manager_auth) required
@@ -16925,6 +17005,12 @@ namespace TalonOne.Api
             // make the HTTP request
 
             var localVarResponse = await this.AsynchronousClient.PostAsync<Import>("/v1/applications/{applicationId}/campaigns/{campaignId}/import_referrals", localVarRequestOptions, this.Configuration);
+
+            if (upFileStream != null)
+            {
+                upFileStream.Close();
+                upFileStream.Dispose();
+            }
 
             if (this.ExceptionFactory != null)
             {

--- a/src/TalonOne/Client/ClientUtils.cs
+++ b/src/TalonOne/Client/ClientUtils.cs
@@ -92,6 +92,16 @@ namespace TalonOne.Client
         }
 
         /// <summary>
+        /// Converts upFile contents from string to Memory Stream
+        /// </summary>
+        /// <param name="upFile">The file with the information about the data that should be imported.</param>
+        /// <returns>The file in a Memory Stream.</returns>
+        public static MemoryStream ParameterToStream(string upFile)
+        {
+            return new MemoryStream(Encoding.ASCII.GetBytes(File.ReadAllText(upFile)));
+        }
+
+        /// <summary>
         /// URL encode a string
         /// Credit/Ref: https://github.com/restsharp/RestSharp/blob/master/RestSharp/Extensions/StringExtensions.cs#L50
         /// </summary>


### PR DESCRIPTION
Hi guys,

We've been testing imports by using this C# nuget package and found out that FormParameters passed into RestRequest needed to be FileParameters with a MemoryStream. We've tested all of these changes and we can confirm that everything is now importing correctly.

We reported this issue to "Skylar Gifford" and the error we were getting is below which makes sense because the request needs a file stream and not a form parameter.

"Error calling ImportLoyaltyPoints: {"message":"no multipart boundary param in Content-Type","errors":null,"StatusCode":400}"

Thanks and let me know if you have any questions.
[dvalecillos@stampinup.com](dvalecillos@stampinup.com)
Stampin' Up Sr Software Engineer 